### PR TITLE
Añadir hash_id a los scrappers de chiapas que no tenían.

### DIFF
--- a/scripts/paralelizado/paralelo_amber_chiapas.py
+++ b/scripts/paralelizado/paralelo_amber_chiapas.py
@@ -4,6 +4,8 @@ import json
 import time
 import datetime
 import random
+import hashlib
+import re
 import psycopg2
 import multiprocessing
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -12,40 +14,118 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 DB_NAME = "cda_busqueda"
 DB_USER = "postgres"
 DB_PASSWORD = "mysecretpassword"
-DB_HOST = "postgres"
+DB_HOST = "postgres" # cambiar
 DB_PORT = "5432"
 
-# Función para insertar múltiples registros en la base de datos
-def insert_many_to_db(data_list: list, extraction_date: datetime.date, source_url: str):
+#
+# ------------------ Helpers: hash y S3 (S3 comentado) ------------------
+#
+
+# s3 = boto3.client("s3")
+# S3_BUCKET = "cdas-2025-alertas-amber"
+# S3_PREFIX = "pdf"
+
+def normalize_for_hash(value):
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip().lower()
+
+def make_hashid(parsed_data):
+    """
+    Genera hash a partir de:
+    folio, localizado, nombre, edad, descripcion_hechos, senas
+    Prefijo: 0502_
+    """
+    parts = [
+        normalize_for_hash(parsed_data.get("folio")),
+        normalize_for_hash(parsed_data.get("localizado")),
+        normalize_for_hash(parsed_data.get("nombre")),
+        normalize_for_hash(parsed_data.get("edad")),
+        normalize_for_hash(parsed_data.get("descripcion_hechos")),
+        normalize_for_hash(parsed_data.get("senas")),
+    ]
+    joined = "||".join(parts)
+    h = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:10]
+    hashid = f"0502_{h}"
+    filename = f"{hashid}.pdf"
+    # s3_key = f"{S3_PREFIX}/{filename}"
+    s3_key = None  # S3 deshabilitado por ahora
+    return hashid, filename, s3_key
+
+
+# Insertar con deduplicación por (hashid, localizado)
+def insert_many_to_db(data_list: list, extraction_date: datetime.date):
+    """
+    data_list: lista de tuplas (detalle_url, ficha_data)
+    """
     if not data_list:
-        return  
-    
-    start_time = time.time()  
+        return
+
+    start_time = time.time()
+    conn = None
+    cur = None
     try:
         conn = psycopg2.connect(
             dbname=DB_NAME,
             user=DB_USER,
             password=DB_PASSWORD,
             host=DB_HOST,
-            port=DB_PORT
+            port=DB_PORT,
         )
         cur = conn.cursor()
 
-        insert_query = """
-            INSERT INTO public.desaparecidos (fecha_extraccion, url_origen, datos)
-            VALUES (%s, %s, %s)
-        """
-        cur.executemany(insert_query, [
-            (extraction_date, source_url, json.dumps(data)) for data in data_list
-        ])
+        for detalle_url, data in data_list:
+            if not data:
+                continue
+
+            hashid, filename, s3_key = make_hashid(data)
+            localizado = data.get("localizado", False)
+
+            # ---------------- S3 (COMENTADO) ----------------
+            # Bloque intencionalmente comentado: este scraper todavía no descarga PDFs.
+            # try:
+            #     if not s3_object_exists(s3, S3_BUCKET, s3_key):
+            #         uploaded = upload_pdf_to_s3_if_not_exists(pdf_bytes, S3_BUCKET, s3_key, s3)
+            #     else:
+            #         print(f"☑️ Ya existe en S3: s3://{S3_BUCKET}/{s3_key}")
+            #         uploaded = False
+            # except Exception as e:
+            #     print(f"❌ Error verificando/guardando en S3: {e}")
+            #     uploaded = False
+            # ---------------- Fin S3 ----------------
+
+            # Checar duplicado antes de insertar
+            cur.execute(
+                "SELECT 1 FROM public.desaparecidos WHERE hashid = %s AND localizado = %s LIMIT 1",
+                (hashid, localizado),
+            )
+            if cur.fetchone() is not None:
+                continue
+
+            cur.execute(
+                """
+                INSERT INTO public.desaparecidos
+                  (fecha_extraccion, url_origen, localizado, hashid, datos)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (extraction_date, detalle_url, localizado, hashid, json.dumps(data)),
+            )
+
         conn.commit()
-    
+
     except Exception as e:
-        print(f"❌ Error al conectar a la base de datos: {e}")
-    
+        print(f"❌ Error al conectar/insertar en la base de datos: {e}")
     finally:
-        cur.close()
-        conn.close()
+        if cur:
+            try:
+                cur.close()
+            except Exception:
+                pass
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
     end_time = time.time()
     print(f"⏳ Tiempo de escritura en BD: {end_time - start_time:.2f} segundos")
@@ -92,6 +172,15 @@ def extract_data(html_content):
     imagen_url = f"{base_url}/{imagen_tag['src'].lstrip('/')}" if imagen_tag else None
     imagen_url = imagen_url.replace("../", "")
 
+    # Determinar localizado (heurística basada en texto)
+    full_text = html_content.lower()
+    if re.search(r"\bno\s*localizad", full_text, flags=re.IGNORECASE):
+        localizado = False
+    elif re.search(r"\blocalizad", full_text, flags=re.IGNORECASE):
+        localizado = True
+    else:
+        localizado = False
+
     # Extraer datos generales
     data = {
         "reporte_num": (soup.find('p', class_='pNoAlerta') or {}).get_text(strip=True),
@@ -119,6 +208,12 @@ def extract_data(html_content):
             if key in text:
                 data[value] = (p.find('b', class_='p2') or {}).get_text(strip=True)
 
+    # Campos normalizados para hash (igual a serial_amber_chiapas.py)
+    data["folio"] = data.get("reporte_num")
+    data["senas"] = data.get("senas_particulares")
+    data["localizado"] = localizado
+    data["estado_alerta"] = "Desaparecidos Amber Chiapas"
+
     return data
 
 # Scraping de fichas en paralelo
@@ -127,7 +222,7 @@ def process_ficha(url):
         response = requests.get(url)
         if response.status_code != 200:
             return None
-        return extract_data(response.text)
+        return (url, extract_data(response.text))
     except:
         return None  
 
@@ -163,7 +258,7 @@ def main():
     global_start_time = time.time()
     extraction_date = datetime.date.today()
     scraped_data = scrape_all_fichas()
-    insert_many_to_db(scraped_data, extraction_date, "https://www.amberchiapas.org.mx/Estatales.aspx")
+    insert_many_to_db(scraped_data, extraction_date)
     global_end_time = time.time()
     print(f"⏳ Tiempo total de ejecución: {global_end_time - global_start_time:.2f} segundos")
 

--- a/scripts/paralelizado/paralelo_havistoa_chiapas.py
+++ b/scripts/paralelizado/paralelo_havistoa_chiapas.py
@@ -4,6 +4,8 @@ import json
 import time
 import datetime
 import random
+import hashlib
+import re
 import psycopg2
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import multiprocessing
@@ -12,15 +14,55 @@ import multiprocessing
 DB_NAME = "cda_busqueda"
 DB_USER = "postgres"
 DB_PASSWORD = "mysecretpassword"
-DB_HOST = "postgres"
+DB_HOST = "postgres" # cambiar
 DB_PORT = "5432"
 
-def insert_many_to_db(data_list: list, extraction_date: datetime.date):
-    """Inserta registros en la base de datos."""
-    if not data_list:
-        return  
+#
+# ------------------ Helpers: hash y S3 (S3 comentado) ------------------
+#
 
-    start_time = time.time()  
+# s3 = boto3.client("s3")
+# S3_BUCKET = "cdas-2025-alertas-amber"
+# S3_PREFIX = "pdf"
+
+def normalize_for_hash(value):
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip().lower()
+
+def make_hashid(parsed_data):
+    """
+    Genera hash a partir de:
+    folio, localizado, nombre, edad, descripcion_hechos, senas
+    Prefijo: 0501_
+    """
+    parts = [
+        normalize_for_hash(parsed_data.get("folio")),
+        normalize_for_hash(parsed_data.get("localizado")),
+        normalize_for_hash(parsed_data.get("nombre")),
+        normalize_for_hash(parsed_data.get("edad")),
+        normalize_for_hash(parsed_data.get("descripcion_hechos")),
+        normalize_for_hash(parsed_data.get("senas")),
+    ]
+    joined = "||".join(parts)
+    h = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:10]
+    hashid = f"0501_{h}"
+    filename = f"{hashid}.pdf"
+    # s3_key = f"{S3_PREFIX}/{filename}"
+    s3_key = None  # S3 deshabilitado por ahora
+    return hashid, filename, s3_key
+
+
+def insert_many_to_db(data_list: list, extraction_date: datetime.date):
+    """
+    data_list: lista de tuplas (detalle_url, ficha_data)
+    """
+    if not data_list:
+        return
+
+    start_time = time.time()
+    conn = None
+    cur = None
 
     try:
         conn = psycopg2.connect(
@@ -28,25 +70,62 @@ def insert_many_to_db(data_list: list, extraction_date: datetime.date):
             user=DB_USER,
             password=DB_PASSWORD,
             host=DB_HOST,
-            port=DB_PORT
+            port=DB_PORT,
         )
         cur = conn.cursor()
 
-        insert_query = """
-            INSERT INTO public.desaparecidos (fecha_extraccion, url_origen, datos)
-            VALUES (%s, %s, %s)
-        """
-        cur.executemany(insert_query, [
-            (extraction_date, url, json.dumps(data)) for url,data in data_list
-        ])
+        for detalle_url, data in data_list:
+            if not data:
+                continue
+
+            hashid, filename, s3_key = make_hashid(data)
+            localizado = data.get("localizado", False)
+
+            # ---------------- S3 (COMENTADO) ----------------
+            # Bloque intencionalmente comentado: este scraper todavía no descarga PDFs.
+            # try:
+            #     if not s3_object_exists(s3, S3_BUCKET, s3_key):
+            #         uploaded = upload_pdf_to_s3_if_not_exists(pdf_bytes, S3_BUCKET, s3_key, s3)
+            #     else:
+            #         print(f"☑️ Ya existe en S3: s3://{S3_BUCKET}/{s3_key}")
+            #         uploaded = False
+            # except Exception as e:
+            #     print(f"❌ Error verificando/guardando en S3: {e}")
+            #     uploaded = False
+            # ---------------- Fin S3 ----------------
+
+            # Checar duplicado antes de insertar
+            cur.execute(
+                "SELECT 1 FROM public.desaparecidos WHERE hashid = %s AND localizado = %s LIMIT 1",
+                (hashid, localizado),
+            )
+            if cur.fetchone() is not None:
+                continue
+
+            cur.execute(
+                """
+                INSERT INTO public.desaparecidos
+                  (fecha_extraccion, url_origen, localizado, hashid, datos)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (extraction_date, detalle_url, localizado, hashid, json.dumps(data)),
+            )
+
         conn.commit()
-        
+
     except Exception as e:
-        print(f"❌ Error al conectar a la base de datos: {e}")
-    
+        print(f"❌ Error al conectar/insertar en la base de datos: {e}")
     finally:
-        cur.close()
-        conn.close()
+        if cur:
+            try:
+                cur.close()
+            except Exception:
+                pass
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
     end_time = time.time()
     print(f"⏳ Tiempo de escritura en BD: {end_time - start_time:.2f} segundos")
@@ -78,6 +157,14 @@ def get_all_ficha_urls():
 def extract_data(data_section: BeautifulSoup):
     """Extrae la información de una ficha desde una sección HTML."""
     try:
+        text_all = data_section.get_text(" ", strip=True).lower() if data_section else ""
+        if re.search(r"\bno\s*localizad", text_all, flags=re.IGNORECASE):
+            localizado = False
+        elif re.search(r"\blocalizad", text_all, flags=re.IGNORECASE):
+            localizado = True
+        else:
+            localizado = False
+
         return {
             "nombre": data_section.find('h3').get_text(strip=True),
             "imagen_url": data_section.find('img')['src'],
@@ -97,7 +184,8 @@ def extract_data(data_section: BeautifulSoup):
             "originario_de": data_section.find('label', string='Originario de:').find_next('p').get_text(strip=True),
             "fecha_nacimiento": data_section.find('b', string='Fecha de nacimiento:').find_next('p').get_text(strip=True),
             "senas_particulares": data_section.find('strong', string='Señas Particulares:').find_next('p').get_text(strip=True),
-            "circunstancia": data_section.find('strong', string='Circunstancia:').find_next('p').get_text(strip=True)
+            "circunstancia": data_section.find('strong', string='Circunstancia:').find_next('p').get_text(strip=True),
+            "localizado": localizado,
         }
     except:
         return None  
@@ -160,7 +248,31 @@ def main():
     extraction_date = datetime.date.today()
     # SCRAPING
     scraped_data = scrape_all_fichas()
-    # Insercion en BD
+
+    # Normalizar campos para hash (igual a serial_havistoa_chiapas.py)
+    for detalle_url, ficha_data in scraped_data:
+        if not ficha_data:
+            continue
+
+        ficha_data["folio"] = ficha_data.get("registro")
+        ficha_data["senas"] = ficha_data.get("senas_particulares")
+        ficha_data["descripcion_hechos"] = ficha_data.get("circunstancia")
+        ficha_data["estado_alerta"] = "Desaparecidos Hasvistoa Chiapas"
+
+        # Edad calculada con (fecha_desaparicion - fecha_nacimiento)
+        fecha_nacimiento = ficha_data.get("fecha_nacimiento")
+        fecha_desaparicion = ficha_data.get("fecha_desaparicion")
+        edad = None
+        if fecha_nacimiento and fecha_desaparicion:
+            try:
+                birth = datetime.datetime.strptime(fecha_nacimiento, "%d/%m/%Y")
+                disp = datetime.datetime.strptime(fecha_desaparicion, "%d/%m/%Y")
+                edad = disp.year - birth.year - ((disp.month, disp.day) < (birth.month, birth.day))
+            except Exception:
+                edad = None
+        ficha_data["edad"] = edad
+
+    # Insercion en BD (deduplicada por hashid/localizado)
     insert_many_to_db(scraped_data, extraction_date)
 
     global_end_time = time.time()

--- a/scripts/serial/serial_amber_chiapas.py
+++ b/scripts/serial/serial_amber_chiapas.py
@@ -3,6 +3,8 @@ from bs4 import BeautifulSoup
 import json
 import time
 import datetime
+import hashlib
+import re
 import psycopg2
 
 # Configuración de la base de datos
@@ -12,42 +14,91 @@ DB_PASSWORD = "mysecretpassword"
 DB_HOST = "postgres"
 DB_PORT = "5432"
 
-# Función para insertar múltiples registros en la base de datos
-def insert_many_to_db(data_list: list, extraction_date: datetime.date):
-    if not data_list:
-        print("⚠️ No hay datos para insertar en la base de datos.")
-        return  
-    
-    start_time = time.time()  
+#
+# ------------------ Helpers: hash y S3 (S3 comentado) ------------------
+#
+
+# s3 = boto3.client("s3")
+# S3_BUCKET = "cdas-2025-alertas-amber"
+# S3_PREFIX = "pdf"
+
+def normalize_for_hash(value):
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip().lower()
+
+def make_hashid(parsed_data):
+    """
+    Genera hash a partir de:
+    folio, localizado, nombre, edad, descripcion_hechos, senas
+    """
+    parts = [
+        normalize_for_hash(parsed_data.get("folio")),
+        normalize_for_hash(parsed_data.get("localizado")),
+        normalize_for_hash(parsed_data.get("nombre")),
+        normalize_for_hash(parsed_data.get("edad")),
+        normalize_for_hash(parsed_data.get("descripcion_hechos")),
+        normalize_for_hash(parsed_data.get("senas")),
+    ]
+    joined = "||".join(parts)
+    h = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:10]
+    hashid = f"0502_{h}"
+    filename = f"{hashid}.pdf"
+    # s3_key = f"{S3_PREFIX}/{filename}"
+    s3_key = None  # S3 deshabilitado por ahora
+    return hashid, filename, s3_key
+
+
+def insert_into_db(data: dict, detalle_url: str, hashid: str):
+    extraction_date = datetime.date.today()
+    localizado = data.get("localizado", False)
+
+    conn = None
+    cur = None
     try:
         conn = psycopg2.connect(
             dbname=DB_NAME,
             user=DB_USER,
             password=DB_PASSWORD,
             host=DB_HOST,
-            port=DB_PORT
+            port=DB_PORT,
         )
         cur = conn.cursor()
 
-        insert_query = """
-            INSERT INTO public.desaparecidos (fecha_extraccion, url_origen, datos)
-            VALUES (%s, %s, %s)
-        """
-        cur.executemany(insert_query, [
-            (extraction_date, url, json.dumps(data)) for url, data in data_list
-        ])
-        conn.commit()
-        print(f"✅ {len(data_list)} registros insertados correctamente.")
-        
-    except Exception as e:
-        print(f"❌ Error al conectar a la base de datos: {e}")
-    
-    finally:
-        cur.close()
-        conn.close()
+        # Verificar existencia exactamente para (hashid, localizado)
+        cur.execute(
+            "SELECT 1 FROM public.desaparecidos WHERE hashid = %s AND localizado = %s LIMIT 1",
+            (hashid, localizado),
+        )
+        exists = cur.fetchone() is not None
+        if exists:
+            print(f"✔ No hay que insertar: ya existe hashid={hashid} y localizado={localizado}")
+            return False
 
-    end_time = time.time()
-    print(f"⏳ Tiempo de escritura en BD: {end_time - start_time:.2f} segundos")
+        query = """
+            INSERT INTO public.desaparecidos (fecha_extraccion, url_origen, localizado, hashid, datos)
+            VALUES (%s, %s, %s, %s, %s)
+        """
+        cur.execute(query, (extraction_date, detalle_url, localizado, hashid, json.dumps(data)))
+        conn.commit()
+        print(f"✅ Insertado en DB: hashid={hashid}")
+        return True
+
+    except Exception as e:
+        print(f"❌ Error al insertar en la base de datos: {e}")
+        return False
+
+    finally:
+        if cur:
+            try:
+                cur.close()
+            except Exception:
+                pass
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
 # Obtener todas las URLs de fichas desde el JSON
 def get_all_ficha_urls():
@@ -91,6 +142,15 @@ def extract_data(html_content):
     imagen_url = f"{base_url}/{imagen_tag['src'].lstrip('/')}" if imagen_tag else None
     imagen_url = imagen_url.replace("../", "")
 
+    # Determinar localizado (heurística basada en texto)
+    full_text = html_content.lower()
+    if re.search(r"\bno\s*localizad", full_text, flags=re.IGNORECASE):
+        localizado = False
+    elif re.search(r"\blocalizad", full_text, flags=re.IGNORECASE):
+        localizado = True
+    else:
+        localizado = False
+
     # Extraer datos generales
     data = {
         "reporte_num": (soup.find('p', class_='pNoAlerta') or {}).get_text(strip=True),
@@ -117,6 +177,12 @@ def extract_data(html_content):
         for key, value in mapping.items():
             if key in text:
                 data[value] = (p.find('b', class_='p2') or {}).get_text(strip=True)
+
+    # Normalizar nombres de campos para el hash (igual que Michoacán)
+    data["folio"] = data.get("reporte_num")
+    data["senas"] = data.get("senas_particulares")
+    data["localizado"] = localizado
+    data["estado_alerta"] = "Desaparecidos Amber Chiapas"
 
     return data if any(data.values()) else None  # Retorna None si no hay datos útiles
 
@@ -148,13 +214,31 @@ def scrape_all_fichas():
 
 def main():
     global_start_time = time.time()
-    extraction_date = datetime.date.today()
     
     # 🔄 Ejecutando scraping en **modo serial**
     scraped_data = scrape_all_fichas()
-    
-    # 🔄 Insertar datos en BD
-    insert_many_to_db(scraped_data, extraction_date)
+
+    # 🔄 Insertar datos en BD (con hash + deduplicación por hashid/localizado)
+    for detalle_url, ficha_data in scraped_data:
+        if not ficha_data:
+            continue
+
+        hashid, filename, s3_key = make_hashid(ficha_data)
+
+        # ---------------- S3 (COMENTADO) ----------------
+        # Bloque intencionalmente comentado: todavía no tenemos PDF bytes en este scraper.
+        # try:
+        #     if not s3_object_exists(s3, S3_BUCKET, s3_key):
+        #         uploaded = upload_pdf_to_s3_if_not_exists(pdf_bytes, S3_BUCKET, s3_key, s3)
+        #     else:
+        #         print(f"☑️ Ya existe en S3: s3://{S3_BUCKET}/{s3_key}")
+        #         uploaded = False
+        # except Exception as e:
+        #     print(f"❌ Error verificando/guardando en S3: {e}")
+        #     uploaded = False
+        # ---------------- Fin S3 ----------------
+
+        insert_into_db(ficha_data, detalle_url, hashid)
     
     global_end_time = time.time()
     print(f"⏳ Tiempo total de ejecución: {global_end_time - global_start_time:.2f} segundos")

--- a/scripts/serial/serial_havistoa_chiapas.py
+++ b/scripts/serial/serial_havistoa_chiapas.py
@@ -4,6 +4,8 @@ import json
 import time
 import datetime
 import random
+import hashlib
+import re
 import psycopg2
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import multiprocessing
@@ -15,13 +17,46 @@ DB_PASSWORD = "mysecretpassword"
 DB_HOST = "postgres"
 DB_PORT = "5432"
 
-def insert_many_to_db(data_list: list, extraction_date: datetime.date):
-    """Inserta registros en la base de datos."""
-    if not data_list:
-        return  
+# ------------------ Helpers: hash y S3 (S3 comentado) ------------------
 
-    start_time = time.time()  
+# s3 = boto3.client("s3")
+# S3_BUCKET = "cdas-2025-alertas-amber"
+# S3_PREFIX = "pdf"
 
+def normalize_for_hash(value):
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip().lower()
+
+def make_hashid(parsed_data):
+    """
+    Genera el hash a partir de:
+    folio, localizado, nombre, edad, descripcion_hechos, senas
+    Prefijo: 0501_
+    """
+    parts = [
+        normalize_for_hash(parsed_data.get("folio")),
+        normalize_for_hash(parsed_data.get("localizado")),
+        normalize_for_hash(parsed_data.get("nombre")),
+        normalize_for_hash(parsed_data.get("edad")),
+        normalize_for_hash(parsed_data.get("descripcion_hechos")),
+        normalize_for_hash(parsed_data.get("senas")),
+    ]
+    joined = "||".join(parts)
+    h = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:10]
+    hashid = f"0501_{h}"
+    filename = f"{hashid}.pdf"
+    # s3_key = f"{S3_PREFIX}/{filename}"
+    s3_key = None  # S3 deshabilitado por ahora
+    return hashid, filename, s3_key
+
+
+def insert_into_db(data: dict, detalle_url: str, hashid: str):
+    extraction_date = datetime.date.today()
+    localizado = data.get("localizado", False)
+
+    conn = None
+    cur = None
     try:
         conn = psycopg2.connect(
             dbname=DB_NAME,
@@ -32,24 +67,40 @@ def insert_many_to_db(data_list: list, extraction_date: datetime.date):
         )
         cur = conn.cursor()
 
-        insert_query = """
-            INSERT INTO public.desaparecidos (fecha_extraccion, url_origen, datos)
-            VALUES (%s, %s, %s)
-        """
-        cur.executemany(insert_query, [
-            (extraction_date, url, json.dumps(data)) for url,data in data_list
-        ])
-        conn.commit()
-        
-    except Exception as e:
-        print(f"❌ Error al conectar a la base de datos: {e}")
-    
-    finally:
-        cur.close()
-        conn.close()
+        # Verificar existencia exactamente para (hashid, localizado)
+        cur.execute(
+            "SELECT 1 FROM public.desaparecidos WHERE hashid = %s AND localizado = %s LIMIT 1",
+            (hashid, localizado),
+        )
+        exists = cur.fetchone() is not None
+        if exists:
+            print(f"✔ No hay que insertar: ya existe hashid={hashid} y localizado={localizado}")
+            return False
 
-    end_time = time.time()
-    print(f"⏳ Tiempo de escritura en BD: {end_time - start_time:.2f} segundos")
+        query = """
+            INSERT INTO public.desaparecidos (fecha_extraccion, url_origen, localizado, hashid, datos)
+            VALUES (%s, %s, %s, %s, %s)
+        """
+        cur.execute(query, (extraction_date, detalle_url, localizado, hashid, json.dumps(data)))
+        conn.commit()
+        print(f"✅ Insertado en DB: hashid={hashid}")
+        return True
+
+    except Exception as e:
+        print(f"❌ Error al insertar en la base de datos: {e}")
+        return False
+
+    finally:
+        if cur:
+            try:
+                cur.close()
+            except Exception:
+                pass
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
 
 # Extraer los URLs de cada ficha desde el JSON
 def get_all_ficha_urls():
@@ -78,6 +129,14 @@ def get_all_ficha_urls():
 def extract_data(data_section: BeautifulSoup):
     """Extrae la información de una ficha desde una sección HTML."""
     try:
+        text_all = data_section.get_text(" ", strip=True).lower() if data_section else ""
+        if re.search(r"\bno\s*localizad", text_all, flags=re.IGNORECASE):
+            localizado = False
+        elif re.search(r"\blocalizad", text_all, flags=re.IGNORECASE):
+            localizado = True
+        else:
+            localizado = False
+
         return {
             "nombre": data_section.find('h3').get_text(strip=True),
             "imagen_url": data_section.find('img')['src'],
@@ -97,7 +156,8 @@ def extract_data(data_section: BeautifulSoup):
             "originario_de": data_section.find('label', string='Originario de:').find_next('p').get_text(strip=True),
             "fecha_nacimiento": data_section.find('b', string='Fecha de nacimiento:').find_next('p').get_text(strip=True),
             "senas_particulares": data_section.find('strong', string='Señas Particulares:').find_next('p').get_text(strip=True),
-            "circunstancia": data_section.find('strong', string='Circunstancia:').find_next('p').get_text(strip=True)
+            "circunstancia": data_section.find('strong', string='Circunstancia:').find_next('p').get_text(strip=True),
+            "localizado": localizado,
         }
     except:
         return None  
@@ -141,11 +201,49 @@ def main():
     """Ejecuta el scraping desde el JSON sin paginación."""
     global_start_time = time.time()
 
-    extraction_date = datetime.date.today()
     # SCRAPING
     scraped_data = scrape_all_fichas()
-    # Insercion en BD
-    insert_many_to_db(scraped_data, extraction_date)
+
+    # Insercion en BD (hash + deduplicación por hash/localizado)
+    for detalle_url, ficha_data in scraped_data:
+        if not ficha_data:
+            continue
+
+        # Normalizar campos para el hash (mismo esquema que Michoacán)
+        ficha_data["folio"] = ficha_data.get("registro")
+        ficha_data["senas"] = ficha_data.get("senas_particulares")
+        ficha_data["descripcion_hechos"] = ficha_data.get("circunstancia")
+        ficha_data["estado_alerta"] = "Desaparecidos Hasvistoa Chiapas"
+
+        # Edad calculada con (fecha_desaparicion - fecha_nacimiento)
+        fecha_nacimiento = ficha_data.get("fecha_nacimiento")
+        fecha_desaparicion = ficha_data.get("fecha_desaparicion")
+        edad = None
+        if fecha_nacimiento and fecha_desaparicion:
+            try:
+                birth = datetime.datetime.strptime(fecha_nacimiento, "%d/%m/%Y")
+                disp = datetime.datetime.strptime(fecha_desaparicion, "%d/%m/%Y")
+                edad = disp.year - birth.year - ((disp.month, disp.day) < (birth.month, birth.day))
+            except Exception:
+                edad = None
+        ficha_data["edad"] = edad
+
+        hashid, filename, s3_key = make_hashid(ficha_data)
+
+        # ---------------- S3 (COMENTADO) ----------------
+        # Bloque intencionalmente comentado: todavía no tenemos PDF bytes en este scraper.
+        # try:
+        #     if not s3_object_exists(s3, S3_BUCKET, s3_key):
+        #         uploaded = upload_pdf_to_s3_if_not_exists(pdf_bytes, S3_BUCKET, s3_key, s3)
+        #     else:
+        #         print(f"☑️ Ya existe en S3: s3://{S3_BUCKET}/{s3_key}")
+        #         uploaded = False
+        # except Exception as e:
+        #     print(f"❌ Error verificando/guardando en S3: {e}")
+        #     uploaded = False
+        # ---------------- Fin S3 ----------------
+
+        insert_into_db(ficha_data, detalle_url, hashid)
 
     global_end_time = time.time()
     print(f"⏳ Tiempo total de ejecución: {global_end_time - global_start_time:.2f} segundos")


### PR DESCRIPTION
## Resumen
Actualiza los scrapers de Chiapas (serial y paralelo) para generar `hashid` con prefijos por tipo de alerta y evitar duplicados en PostgreSQL usando deduplicación por `(hashid, localizado)`.

## Cambios
- `serial_amber_chiapas.py` / `paralelo_amber_chiapas.py`
  - `hashid` con prefijo `0502_`
  - Inserta en `public.desaparecidos` solo si no existe `(hashid, localizado)`
  - Se agregó lógica de S3, pero queda **comentada** (sin subir PDFs)

- `serial_havistoa_chiapas.py` / `paralelo_havistoa_chiapas.py`
  - `hashid` con prefijo `0501_`
  - Inserta en `public.desaparecidos` solo si no existe `(hashid, localizado)`
  - Se agregó lógica de S3, pero queda **comentada** (sin subir PDFs)

## Lo que hice:
- Correr los scrapers y verificar que los registros no se duplican por `(hashid, localizado)`.
- Confirmar que los `hashid` creados inician con `0502_` (Amber) y `0501_` (Hasvistoa).